### PR TITLE
fix: issue creation event match

### DIFF
--- a/src/github2feishu.ts
+++ b/src/github2feishu.ts
@@ -79,7 +79,7 @@ export async function PostGithubEvent(): Promise<number | undefined> {
       detailurl = comment?.html_url || ''
       break
     }
-    case 'issue': {
+    case 'issues': {
       const issue = context.payload.issue
       etitle = `[No.${issue?.number} ${issue?.title}](${issue?.html_url})\n\n${issue?.body}\n\n`
       detailurl = issue?.html_url || ''


### PR DESCRIPTION
• - Right now the creation event doesn’t hit the code path that adds the title: the switch looks for case 'issue' while GitHub sends eventName === 'issues'.
    Because of that mismatch, the issue block at src/github2feishu.ts:82-86 never runs, and the message falls back to the default etitle that’s set to the
    issue URL only (no title) at src/github2feishu.ts:35-39.
  - The bot does include the issue title for issue_comment events ([No.X <title>] at src/github2feishu.ts:76-80), but not for the initial issue creation
    because of the event name mismatch.